### PR TITLE
Align bit buffer output after emitting last end block.

### DIFF
--- a/src/ZlibStream/Deflate.Quick.cs
+++ b/src/ZlibStream/Deflate.Quick.cs
@@ -39,6 +39,7 @@ namespace SixLabors.ZlibStream
                     {
                         last = flush == ZlibFlushStrategy.ZFINISH;
                         this.Tr_emit_tree(STATICTREES, last);
+                        this.blockOpen = true;
                     }
 
                     do
@@ -59,8 +60,9 @@ namespace SixLabors.ZlibStream
                             this.Fill_window();
                             if (this.lookahead < MINLOOKAHEAD && flush == ZlibFlushStrategy.ZNOFLUSH)
                             {
-                                this.Tr_emit_end_block(StaticTree.StaticLtree);
+                                this.Tr_emit_end_block(StaticTree.StaticLtree, false);
                                 this.blockStart = this.strStart;
+                                this.blockOpen = false;
                                 this.Flush_pending(this.strm);
                                 return NeedMore;
                             }
@@ -76,7 +78,7 @@ namespace SixLabors.ZlibStream
                             hash_head = this.InsertString(prev, head, window, this.strStart);
                             dist = this.strStart - hash_head;
 
-                            if (dist > 0 && (dist - 1) < this.wSize - 1)
+                            if (dist > 0 && dist < this.wSize - MINLOOKAHEAD)
                             {
                                 matchLen = this.Compare_258_Unaligned_16(window + this.strStart, window + hash_head);
 
@@ -113,8 +115,9 @@ namespace SixLabors.ZlibStream
                     }
 
                     last = flush == ZlibFlushStrategy.ZFINISH;
-                    this.Tr_emit_end_block(StaticTree.StaticLtree);
+                    this.Tr_emit_end_block(StaticTree.StaticLtree, last);
                     this.blockStart = this.strStart;
+                    this.blockOpen = false;
                     this.Flush_pending(this.strm);
 
                     if (last)

--- a/src/ZlibStream/Deflate.cs
+++ b/src/ZlibStream/Deflate.cs
@@ -707,7 +707,7 @@ namespace SixLabors.ZlibStream
         private void Tr_align()
         {
             this.Tr_emit_tree(STATICTREES, false);
-            this.Tr_emit_end_block(StaticTree.StaticLtree);
+            this.Tr_emit_end_block(StaticTree.StaticLtree, false);
 
             this.Bi_flush();
 
@@ -718,7 +718,7 @@ namespace SixLabors.ZlibStream
             if (1 + this.lastEobLen + 10 - this.biValid < 9)
             {
                 this.Tr_emit_tree(STATICTREES, false);
-                this.Tr_emit_end_block(StaticTree.StaticLtree);
+                this.Tr_emit_end_block(StaticTree.StaticLtree, false);
                 this.Bi_flush();
             }
 
@@ -915,15 +915,17 @@ namespace SixLabors.ZlibStream
         private void Tr_emit_tree(int type, bool eof)
         {
             this.Send_bits((type << 1) + (eof ? 1 : 0), 3); // send block type
-            this.blockOpen = true;
         }
 
         // Send the end of a block
         [MethodImpl(InliningOptions.ShortMethod)]
-        private void Tr_emit_end_block(ushort[] tree)
+        private void Tr_emit_end_block(ushort[] tree, bool last)
         {
             this.Send_code(ENDBLOCK, tree);
-            this.blockOpen = false;
+            if (last)
+            {
+                this.Bi_windup();
+            }
         }
 
         // Emit match dist/length code.


### PR DESCRIPTION
- Moved blockOpen setting into deflate quick due to inflate using zero length end of block with Z_SYNC_FLUSH. zlib-ng#585
- Fixed invalid distance possible when using deflate quick. zlib-ng#583

I think this should get deflate quick stuff working. I think most of it ended up being not aligning after last end of block, but it might be those other things too. Emitting of tree is tricky.