### PR TITLE
Improved SIMD Adler32

### DIFF
--- a/src/ZlibStream/Adler32.cs
+++ b/src/ZlibStream/Adler32.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 #if SUPPORTS_RUNTIME_INTRINSICS
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
@@ -29,15 +30,15 @@ namespace SixLabors.ZlibStream
         private const uint NMAX = 5552;
 
 #if SUPPORTS_RUNTIME_INTRINSICS
-        private const int MinBufferSize = 64;
+        private const int MinBufferSize = 32;
+        private const byte ShuffleMaskHighToLow = 0b_11_10_11_10;
+        private const byte ShuffleMaskOddToEven = 0b_11_11_01_01;
 
         // The C# compiler emits this as a compile-time constant embedded in the PE file.
-        private static ReadOnlySpan<byte> Tap1Tap2 => new byte[]
+        private static ReadOnlySpan<sbyte> UnrollMultipliers => new sbyte[]
         {
-            64, 63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, // tap1
-            48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, // tap2
-            32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, // tap1
-            16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 // tap2
+            32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17,
+            16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1
         };
 #endif
 
@@ -65,14 +66,9 @@ namespace SixLabors.ZlibStream
             }
 
 #if SUPPORTS_RUNTIME_INTRINSICS
-            if (Avx2.IsSupported && buffer.Length >= MinBufferSize)
-            {
-                return CalculateAvx2(adler, buffer);
-            }
-
             if (Ssse3.IsSupported && buffer.Length >= MinBufferSize)
             {
-                return CalculateSse3(adler, buffer);
+                return CalculateSsse3(adler, buffer);
             }
 
             return CalculateScalar(adler, buffer);
@@ -81,316 +77,238 @@ namespace SixLabors.ZlibStream
 #endif
         }
 
-        // Based on https://github.com/chromium/chromium/blob/master/third_party/zlib/adler32_simd.c
+        // Inspired by https://github.com/chromium/chromium/blob/master/third_party/zlib/adler32_simd.c
 #if SUPPORTS_RUNTIME_INTRINSICS
         [MethodImpl(InliningOptions.ShortMethod)]
-        private static unsafe uint CalculateAvx2(uint adler, ReadOnlySpan<byte> buffer)
+        private static uint CalculateSsse3(uint adler, ReadOnlySpan<byte> buffer)
         {
             uint s1 = adler & 0xFFFF;
-            uint s2 = (adler >> 16) & 0xFFFF;
+            uint s2 = adler >> 16;
 
-            // Process the data in blocks.
-            const int BLOCK_SIZE = 64;
+            ref byte bufRef = ref MemoryMarshal.GetReference(buffer);
+            ref byte endRef = ref Unsafe.Add(ref bufRef, buffer.Length);
 
-            uint length = (uint)buffer.Length;
-            uint blocks = length / BLOCK_SIZE;
-            length -= blocks * BLOCK_SIZE;
-
-            int index = 0;
-            fixed (byte* bufferPtr = buffer)
-            fixed (byte* tapPtr = Tap1Tap2)
+            uint vectors = (uint)Unsafe.ByteOffset(ref bufRef, ref endRef) / (uint)Vector128<byte>.Count;
+            while (vectors > 0)
             {
-                index += (int)blocks * BLOCK_SIZE;
-                var localBufferPtr = bufferPtr;
+                // Process n 128-bit vectors of data. At most NMAX data bytes can be
+                // processed before s2 must be reduced modulo BASE.
+                uint n = Math.Min(vectors, NMAX / (uint)Vector128<byte>.Count);
+                vectors -= n;
 
-                // _mm_setr_epi8 on x86
-                Vector256<sbyte> tap1 = Avx.LoadVector256((sbyte*)tapPtr);
-                Vector256<sbyte> tap2 = Avx.LoadVector256((sbyte*)(tapPtr + 0x20));
-                Vector256<byte> zero = Vector256<byte>.Zero;
-                var ones = Vector256.Create((short)1);
-
-                while (blocks > 0)
+                Vector128<uint> v_s1, v_s2;
+                Vector128<short> vone;
+                if (Avx2.IsSupported && n >= 4)
                 {
-                    uint n = NMAX / BLOCK_SIZE;  /* The NMAX constraint. */
-                    if (n > blocks)
-                    {
-                        n = blocks;
-                    }
+                    // The AVX2 loop handles four 128-bit vectors (64 bytes) per iteration.
+                    Vector256<sbyte> mul2 = Unsafe.As<sbyte, Vector256<sbyte>>(ref MemoryMarshal.GetReference(UnrollMultipliers));
+                    Vector256<sbyte> mul1 = Avx2.Add(Vector256.Create((sbyte)32), mul2);
+                    Vector256<short> wone = Vector256.Create((short)1);
+                    Vector256<byte> zero = Vector256<byte>.Zero;
 
-                    blocks -= n;
-
-                    // Process n blocks of data. At most NMAX data bytes can be
-                    // processed before s2 must be reduced modulo BASE.
-                    Vector256<uint> v_ps = Vector256.CreateScalar(s1 * n);
-                    Vector256<uint> v_s2 = Vector256.CreateScalar(s2);
-                    Vector256<uint> v_s1 = Vector256<uint>.Zero;
+                    Vector256<uint> w_s1 = Vector256.CreateScalar(s1);
+                    Vector256<uint> w_s2 = Vector256.CreateScalar(s2);
+                    Vector256<uint> w_ps = Vector256<uint>.Zero;
 
                     do
                     {
                         // Load 64 input bytes.
-                        Vector256<byte> bytes1 = Avx.LoadDquVector256(localBufferPtr);
-                        Vector256<byte> bytes2 = Avx.LoadDquVector256(localBufferPtr + 0x20);
+                        Vector256<byte> bytes1 = Unsafe.As<byte, Vector256<byte>>(ref bufRef);
+                        Vector256<byte> bytes2 = Unsafe.As<byte, Vector256<byte>>(ref Unsafe.Add(ref bufRef, Vector256<byte>.Count));
+                        bufRef = ref Unsafe.Add(ref bufRef, Vector256<byte>.Count * 2);
+                        n -= 4;
 
-                        // Add previous block byte sum to v_ps.
-                        v_ps = Avx2.Add(v_ps, v_s1);
+                        // We need to accumulate the previous s1 value into s2 64 times each iteration.
+                        // Rather than duplicate the effort, we will keep a running total of the
+                        // previous sums, then multiply the whole thing by 64 and add it to s2 at the end.
+                        w_ps = Avx2.Add(w_ps, w_s1);
 
-                        // Horizontally add the bytes for s1, multiply-adds the
-                        // bytes by [ 32, 31, 30, ... ] for s2.
-                        v_s1 = Avx2.Add(v_s1, Avx2.SumAbsoluteDifferences(bytes1, zero).AsUInt32());
-                        Vector256<short> mad1 = Avx2.MultiplyAddAdjacent(bytes1, tap1);
-                        v_s2 = Avx2.Add(v_s2, Avx2.MultiplyAddAdjacent(mad1, ones).AsUInt32());
+                        // Horizontally add the bytes for s1 -- PSADBW subtracts (zero in this case) and
+                        // then sums sets of 8 adjacent bytes into 16-bit results padded to 64 bits,
+                        // which we then reinterpret as 32-bit values.
+                        // Multiply-add the bytes by [ 64, 63, 62, ... ] for s2 -- PMADDUBSW multiplies
+                        // two byte values then adds adjacent pairs into 16-bit values. Then PMADDWD
+                        // does the same with the short values, yielding one 32-bit sum for each 4
+                        // bytes multiplied by their associated positional multiplier.
+                        w_s1 = Avx2.Add(w_s1, Avx2.SumAbsoluteDifferences(bytes1, zero).AsUInt32());
+                        Vector256<short> mad1 = Avx2.MultiplyAddAdjacent(bytes1, mul1);
+                        w_s2 = Avx2.Add(w_s2, Avx2.MultiplyAddAdjacent(mad1, wone).AsUInt32());
 
-                        v_s1 = Avx2.Add(v_s1, Avx2.SumAbsoluteDifferences(bytes2, zero).AsUInt32());
-                        Vector256<short> mad2 = Avx2.MultiplyAddAdjacent(bytes2, tap2);
-                        v_s2 = Avx2.Add(v_s2, Avx2.MultiplyAddAdjacent(mad2, ones).AsUInt32());
-
-                        localBufferPtr += BLOCK_SIZE;
+                        w_s1 = Avx2.Add(w_s1, Avx2.SumAbsoluteDifferences(bytes2, zero).AsUInt32());
+                        Vector256<short> mad2 = Avx2.MultiplyAddAdjacent(bytes2, mul2);
+                        w_s2 = Avx2.Add(w_s2, Avx2.MultiplyAddAdjacent(mad2, wone).AsUInt32());
                     }
-                    while (--n > 0);
+                    while (n >= 4);
 
-                    v_s2 = Avx2.Add(v_s2, Avx2.ShiftLeftLogical(v_ps, 6));
+                    // Here we take care of accumulating the previous sums.
+                    w_s2 = Avx2.Add(w_s2, Avx2.ShiftLeftLogical(w_ps, 6));
 
-                    // Sum epi32 ints v_s1(s2) and accumulate in s1(s2).
-                    const byte S2301 = 0b1011_0001;  // A B C D -> B A D C
-                    const byte S1032 = 0b0100_1110;  // A B C D -> C D A B
-
-                    v_s1 = Avx2.Add(v_s1, Avx2.Shuffle(v_s1, S1032));
-
-                    s1 += Sse2.ConvertToUInt32(Sse2.Add(v_s1.GetLower(), v_s1.GetUpper()));
-
-                    v_s2 = Avx2.Add(v_s2, Avx2.Shuffle(v_s2, S2301));
-                    v_s2 = Avx2.Add(v_s2, Avx2.Shuffle(v_s2, S1032));
-
-                    s2 = Sse2.ConvertToUInt32(Sse2.Add(v_s2.GetLower(), v_s2.GetUpper()));
-
-                    // Reduce.
-                    s1 %= BASE;
-                    s2 %= BASE;
+                    // Collapse the vectors to 128-bit so they can be carried into the SSSE3 branch.
+                    v_s1 = Sse2.Add(w_s1.GetLower(), w_s1.GetUpper());
+                    v_s2 = Sse2.Add(w_s2.GetLower(), w_s2.GetUpper());
+                    vone = wone.GetLower();
+                }
+                else
+                {
+                    // If the AVX2 loop didn't run, initialize the 128-bit vectors.
+                    v_s1 = Vector128.CreateScalar(s1);
+                    v_s2 = Vector128.CreateScalar(s2);
+                    vone = Vector128.Create((short)1);
                 }
 
-                if (length > 0)
+                if (n != 0)
                 {
-                    if (length >= 16)
-                    {
-                        s2 += s1 += localBufferPtr[0];
-                        s2 += s1 += localBufferPtr[1];
-                        s2 += s1 += localBufferPtr[2];
-                        s2 += s1 += localBufferPtr[3];
-                        s2 += s1 += localBufferPtr[4];
-                        s2 += s1 += localBufferPtr[5];
-                        s2 += s1 += localBufferPtr[6];
-                        s2 += s1 += localBufferPtr[7];
-                        s2 += s1 += localBufferPtr[8];
-                        s2 += s1 += localBufferPtr[9];
-                        s2 += s1 += localBufferPtr[10];
-                        s2 += s1 += localBufferPtr[11];
-                        s2 += s1 += localBufferPtr[12];
-                        s2 += s1 += localBufferPtr[13];
-                        s2 += s1 += localBufferPtr[14];
-                        s2 += s1 += localBufferPtr[15];
+                    // If the input length wasn't a mupliple of 64 or if AVX2 isn't supported,
+                    // process the remainder using SSSE3.
+                    Vector128<sbyte> mul2 = Unsafe.Add(ref Unsafe.As<sbyte, Vector128<sbyte>>(ref MemoryMarshal.GetReference(UnrollMultipliers)), 1);
+                    Vector128<byte> zero = Vector128<byte>.Zero;
 
-                        localBufferPtr += 16;
-                        length -= 16;
+                    if (n >= 2)
+                    {
+                        // This loop mirrors the AVX2 loop above at half the vector width.
+                        // It processes two 128-bit vectors (32 bytes) per iteration.
+                        Vector128<sbyte> mul1 = Unsafe.As<sbyte, Vector128<sbyte>>(ref MemoryMarshal.GetReference(UnrollMultipliers));
+                        Vector128<uint> v_ps = Vector128<uint>.Zero;
+
+                        do
+                        {
+                            Vector128<byte> bytes1 = Unsafe.As<byte, Vector128<byte>>(ref bufRef);
+                            Vector128<byte> bytes2 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref bufRef, Vector128<byte>.Count));
+                            bufRef = ref Unsafe.Add(ref bufRef, Vector128<byte>.Count * 2);
+                            n -= 2;
+
+                            v_ps = Sse2.Add(v_ps, v_s1);
+
+                            v_s1 = Sse2.Add(v_s1, Sse2.SumAbsoluteDifferences(bytes1, zero).AsUInt32());
+                            Vector128<short> mad1 = Ssse3.MultiplyAddAdjacent(bytes1, mul1);
+                            v_s2 = Sse2.Add(v_s2, Sse2.MultiplyAddAdjacent(mad1, vone).AsUInt32());
+
+                            v_s1 = Sse2.Add(v_s1, Sse2.SumAbsoluteDifferences(bytes2, zero).AsUInt32());
+                            Vector128<short> mad2 = Ssse3.MultiplyAddAdjacent(bytes2, mul2);
+                            v_s2 = Sse2.Add(v_s2, Sse2.MultiplyAddAdjacent(mad2, vone).AsUInt32());
+                        }
+                        while (n >= 2);
+
+                        v_s2 = Sse2.Add(v_s2, Sse2.ShiftLeftLogical(v_ps, 5));
                     }
 
-                    while (length-- > 0)
+                    if (n != 0)
                     {
-                        s2 += s1 += *localBufferPtr++;
-                    }
+                        // If there is a trailing 128-bit vector, use a half SSSE3 iteration to finish.
+                        Vector128<byte> bytes1 = Unsafe.As<byte, Vector128<byte>>(ref bufRef);
+                        bufRef = ref Unsafe.Add(ref bufRef, Vector128<byte>.Count);
 
-                    if (s1 >= BASE)
-                    {
-                        s1 -= BASE;
-                    }
+                        v_s2 = Sse2.Add(v_s2, Sse2.ShiftLeftLogical(v_s1, 4));
 
-                    s2 %= BASE;
-                }
-
-                return s1 | (s2 << 16);
-            }
-        }
-
-        [MethodImpl(InliningOptions.ShortMethod)]
-        private static unsafe uint CalculateSse3(uint adler, ReadOnlySpan<byte> buffer)
-        {
-            uint s1 = adler & 0xFFFF;
-            uint s2 = (adler >> 16) & 0xFFFF;
-
-            // Process the data in blocks.
-            const int BLOCK_SIZE = 32;
-
-            uint length = (uint)buffer.Length;
-            uint blocks = length / BLOCK_SIZE;
-            length -= blocks * BLOCK_SIZE;
-
-            int index = 0;
-            fixed (byte* bufferPtr = buffer)
-            fixed (byte* tapPtr = Tap1Tap2.Slice(32))
-            {
-                index += (int)blocks * BLOCK_SIZE;
-                var localBufferPtr = bufferPtr;
-
-                // _mm_setr_epi8 on x86
-                Vector128<sbyte> tap1 = Sse2.LoadVector128((sbyte*)tapPtr);
-                Vector128<sbyte> tap2 = Sse2.LoadVector128((sbyte*)(tapPtr + 0x10));
-                Vector128<byte> zero = Vector128<byte>.Zero;
-                var ones = Vector128.Create((short)1);
-
-                while (blocks > 0)
-                {
-                    uint n = NMAX / BLOCK_SIZE;  /* The NMAX constraint. */
-                    if (n > blocks)
-                    {
-                        n = blocks;
-                    }
-
-                    blocks -= n;
-
-                    // Process n blocks of data. At most NMAX data bytes can be
-                    // processed before s2 must be reduced modulo BASE.
-                    Vector128<uint> v_ps = Vector128.CreateScalar(s1 * n);
-                    Vector128<uint> v_s2 = Vector128.CreateScalar(s2);
-                    Vector128<uint> v_s1 = Vector128<uint>.Zero;
-
-                    do
-                    {
-                        // Load 32 input bytes.
-                        Vector128<byte> bytes1 = Sse3.LoadDquVector128(localBufferPtr);
-                        Vector128<byte> bytes2 = Sse3.LoadDquVector128(localBufferPtr + 0x10);
-
-                        // Add previous block byte sum to v_ps.
-                        v_ps = Sse2.Add(v_ps, v_s1);
-
-                        // Horizontally add the bytes for s1, multiply-adds the
-                        // bytes by [ 32, 31, 30, ... ] for s2.
                         v_s1 = Sse2.Add(v_s1, Sse2.SumAbsoluteDifferences(bytes1, zero).AsUInt32());
-                        Vector128<short> mad1 = Ssse3.MultiplyAddAdjacent(bytes1, tap1);
-                        v_s2 = Sse2.Add(v_s2, Sse2.MultiplyAddAdjacent(mad1, ones).AsUInt32());
-
-                        v_s1 = Sse2.Add(v_s1, Sse2.SumAbsoluteDifferences(bytes2, zero).AsUInt32());
-                        Vector128<short> mad2 = Ssse3.MultiplyAddAdjacent(bytes2, tap2);
-                        v_s2 = Sse2.Add(v_s2, Sse2.MultiplyAddAdjacent(mad2, ones).AsUInt32());
-
-                        localBufferPtr += BLOCK_SIZE;
+                        Vector128<short> mad1 = Ssse3.MultiplyAddAdjacent(bytes1, mul2);
+                        v_s2 = Sse2.Add(v_s2, Sse2.MultiplyAddAdjacent(mad1, vone).AsUInt32());
                     }
-                    while (--n > 0);
-
-                    v_s2 = Sse2.Add(v_s2, Sse2.ShiftLeftLogical(v_ps, 5));
-
-                    // Sum epi32 ints v_s1(s2) and accumulate in s1(s2).
-                    const byte S2301 = 0b1011_0001;  // A B C D -> B A D C
-                    const byte S1032 = 0b0100_1110;  // A B C D -> C D A B
-
-                    v_s1 = Sse2.Add(v_s1, Sse2.Shuffle(v_s1, S1032));
-
-                    // ToScalar isn't optimized pre .NET 5
-                    // https://github.com/dotnet/runtime/pull/37882
-                    s1 += Sse2.ConvertToUInt32(v_s1);
-
-                    v_s2 = Sse2.Add(v_s2, Sse2.Shuffle(v_s2, S2301));
-                    v_s2 = Sse2.Add(v_s2, Sse2.Shuffle(v_s2, S1032));
-
-                    s2 = Sse2.ConvertToUInt32(v_s2);
-
-                    // Reduce.
-                    s1 %= BASE;
-                    s2 %= BASE;
                 }
 
-                if (length > 0)
-                {
-                    if (length >= 16)
-                    {
-                        s2 += s1 += localBufferPtr[0];
-                        s2 += s1 += localBufferPtr[1];
-                        s2 += s1 += localBufferPtr[2];
-                        s2 += s1 += localBufferPtr[3];
-                        s2 += s1 += localBufferPtr[4];
-                        s2 += s1 += localBufferPtr[5];
-                        s2 += s1 += localBufferPtr[6];
-                        s2 += s1 += localBufferPtr[7];
-                        s2 += s1 += localBufferPtr[8];
-                        s2 += s1 += localBufferPtr[9];
-                        s2 += s1 += localBufferPtr[10];
-                        s2 += s1 += localBufferPtr[11];
-                        s2 += s1 += localBufferPtr[12];
-                        s2 += s1 += localBufferPtr[13];
-                        s2 += s1 += localBufferPtr[14];
-                        s2 += s1 += localBufferPtr[15];
+                // Horizontally sum the 2 even elements in the s1 vector.
+                // The odd elements will be zero because PSADBW outputs two 64-bit values.
+                v_s1 = Sse2.Add(v_s1, Sse2.Shuffle(v_s1, ShuffleMaskHighToLow));
+                s1 = Sse2.ConvertToUInt32(v_s1);
 
-                        localBufferPtr += 16;
-                        length -= 16;
-                    }
+                // And horizontally sum the 4 elememts in the s2 vector.
+                v_s2 = Sse2.Add(v_s2, Sse2.Shuffle(v_s2, ShuffleMaskOddToEven));
+                v_s2 = Sse2.Add(v_s2, Sse2.Shuffle(v_s2, ShuffleMaskHighToLow));
+                s2 = Sse2.ConvertToUInt32(v_s2);
 
-                    while (length-- > 0)
-                    {
-                        s2 += s1 += *localBufferPtr++;
-                    }
-
-                    if (s1 >= BASE)
-                    {
-                        s1 -= BASE;
-                    }
-
-                    s2 %= BASE;
-                }
-
-                return s1 | (s2 << 16);
+                // Reduce.
+                s1 %= BASE;
+                s2 %= BASE;
             }
+
+            // This handles at most 15 leftover bytes that didn't fit in the SIMD loop.
+            if (Unsafe.IsAddressLessThan(ref bufRef, ref endRef))
+            {
+                while (!Unsafe.IsAddressGreaterThan(ref bufRef, ref Unsafe.Subtract(ref endRef, 4)))
+                {
+                    s2 += s1 += Unsafe.Add(ref bufRef, 0);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 1);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 2);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 3);
+
+                    bufRef = ref Unsafe.Add(ref bufRef, 4);
+                }
+
+                while (Unsafe.IsAddressLessThan(ref bufRef, ref endRef))
+                {
+                    s2 += s1 += bufRef;
+                    bufRef = ref Unsafe.Add(ref bufRef, 1);
+                }
+
+                if (s1 >= BASE)
+                {
+                    s1 -= BASE;
+                }
+
+                s2 %= BASE;
+            }
+
+            return s1 | (s2 << 16);
         }
 #endif
 
         [MethodImpl(InliningOptions.ShortMethod)]
-        private static unsafe uint CalculateScalar(uint adler, ReadOnlySpan<byte> buffer)
+        private static uint CalculateScalar(uint adler, ReadOnlySpan<byte> buffer)
         {
             uint s1 = adler & 0xFFFF;
-            uint s2 = (adler >> 16) & 0xFFFF;
-            uint k;
+            uint s2 = adler >> 16;
 
-            fixed (byte* bufferPtr = buffer)
+            ref byte bufRef = ref MemoryMarshal.GetReference(buffer);
+            ref byte endRef = ref Unsafe.Add(ref bufRef, buffer.Length);
+
+            while (Unsafe.IsAddressLessThan(ref bufRef, ref endRef))
             {
-                var localBufferPtr = bufferPtr;
-                uint length = (uint)buffer.Length;
+                int blockBytes = Math.Min((int)Unsafe.ByteOffset(ref bufRef, ref endRef), (int)NMAX);
+                ref byte blockEndRef = ref Unsafe.Add(ref bufRef, blockBytes);
 
-                while (length > 0)
+                while (!Unsafe.IsAddressGreaterThan(ref bufRef, ref Unsafe.Subtract(ref blockEndRef, 16)))
                 {
-                    k = length < NMAX ? length : NMAX;
-                    length -= k;
+                    s2 += s1 += Unsafe.Add(ref bufRef, 0);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 1);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 2);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 3);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 4);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 5);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 6);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 7);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 8);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 9);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 10);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 11);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 12);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 13);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 14);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 15);
 
-                    while (k >= 16)
-                    {
-                        s2 += s1 += localBufferPtr[0];
-                        s2 += s1 += localBufferPtr[1];
-                        s2 += s1 += localBufferPtr[2];
-                        s2 += s1 += localBufferPtr[3];
-                        s2 += s1 += localBufferPtr[4];
-                        s2 += s1 += localBufferPtr[5];
-                        s2 += s1 += localBufferPtr[6];
-                        s2 += s1 += localBufferPtr[7];
-                        s2 += s1 += localBufferPtr[8];
-                        s2 += s1 += localBufferPtr[9];
-                        s2 += s1 += localBufferPtr[10];
-                        s2 += s1 += localBufferPtr[11];
-                        s2 += s1 += localBufferPtr[12];
-                        s2 += s1 += localBufferPtr[13];
-                        s2 += s1 += localBufferPtr[14];
-                        s2 += s1 += localBufferPtr[15];
-
-                        localBufferPtr += 16;
-                        k -= 16;
-                    }
-
-                    while (k-- > 0)
-                    {
-                        s2 += s1 += *localBufferPtr++;
-                    }
-
-                    s1 %= BASE;
-                    s2 %= BASE;
+                    bufRef = ref Unsafe.Add(ref bufRef, 16);
                 }
 
-                return (s2 << 16) | s1;
+                while (!Unsafe.IsAddressGreaterThan(ref bufRef, ref Unsafe.Subtract(ref blockEndRef, 4)))
+                {
+                    s2 += s1 += Unsafe.Add(ref bufRef, 0);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 1);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 2);
+                    s2 += s1 += Unsafe.Add(ref bufRef, 3);
+
+                    bufRef = ref Unsafe.Add(ref bufRef, 4);
+                }
+
+                while (Unsafe.IsAddressLessThan(ref bufRef, ref blockEndRef))
+                {
+                    s2 += s1 += bufRef;
+                    bufRef = ref Unsafe.Add(ref bufRef, 1);
+                }
+
+                s1 %= BASE;
+                s2 %= BASE;
             }
+
+            return (s2 << 16) | s1;
         }
     }
 }


### PR DESCRIPTION
I took a stab at cleaning up the Adler32 SIMD implementation and plugging up a few of the performance holes.  Since the current AVX2 version works in 64 byte chunks, the tail of scalar processed bytes can be excessive in some cases.  I've rewritten it to share the AVX2 and SSSE3 code paths so the SSSE3 code can work on the leftovers from the AVX2 loop, improving perf on any lengths not an even multiple of 64 bytes.

Here are some benchmark results showing where it's most improved:

``` ini
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-6700K CPU 4.00GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100-rc.2.20479.15
  [Host]     : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  DefaultJob : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
```

```
|  Method | Count |       Mean |     Error |    StdDev | Ratio |
|-------- |------ |-----------:|----------:|----------:|------:|
|    Base |     8 |   7.127 ns | 0.0256 ns | 0.0239 ns |  1.00 |
|      PR |     8 |   5.385 ns | 0.0311 ns | 0.0276 ns |  0.76 |
|         |       |            |           |           |       |
|    Base |    15 |  10.993 ns | 0.0382 ns | 0.0357 ns |  1.00 |
|      PR |    15 |   7.580 ns | 0.0492 ns | 0.0460 ns |  0.69 |
|         |       |            |           |           |       |
|    Base |    16 |   7.246 ns | 0.0240 ns | 0.0201 ns |  1.00 |
|      PR |    16 |   7.464 ns | 0.0341 ns | 0.0302 ns |  1.03 |
|         |       |            |           |           |       |
|    Base |    24 |  10.598 ns | 0.0316 ns | 0.0295 ns |  1.00 |
|      PR |    24 |   9.468 ns | 0.0443 ns | 0.0414 ns |  0.89 |
|         |       |            |           |           |       |
|    Base |    31 |  14.579 ns | 0.0475 ns | 0.0444 ns |  1.00 |
|      PR |    31 |  11.695 ns | 0.0594 ns | 0.0496 ns |  0.80 |
|         |       |            |           |           |       |
|    Base |    32 |  11.873 ns | 0.0257 ns | 0.0228 ns |  1.00 |
|      PR |    32 |   7.976 ns | 0.0781 ns | 0.0731 ns |  0.67 |
|         |       |            |           |           |       |
|    Base |    48 |  17.575 ns | 0.0676 ns | 0.0600 ns |  1.00 |
|      PR |    48 |   9.041 ns | 0.1453 ns | 0.1359 ns |  0.51 |
|         |       |            |           |           |       |
|    Base |    64 |   8.551 ns | 0.0280 ns | 0.0262 ns |  1.00 |
|      PR |    64 |   8.531 ns | 0.0270 ns | 0.0246 ns |  1.00 |
|         |       |            |           |           |       |
|    Base |    80 |  13.780 ns | 0.0551 ns | 0.0515 ns |  1.00 |
|      PR |    80 |   9.518 ns | 0.0375 ns | 0.0313 ns |  0.69 |
|         |       |            |           |           |       |
|    Base |    96 |  22.112 ns | 0.0968 ns | 0.0858 ns |  1.00 |
|      PR |    96 |  10.294 ns | 0.0628 ns | 0.0587 ns |  0.47 |
|         |       |            |           |           |       |
|    Base |   112 |  31.873 ns | 0.1630 ns | 0.1525 ns |  1.00 |
|      PR |   112 |  10.937 ns | 0.0477 ns | 0.0446 ns |  0.34 |
|         |       |            |           |           |       |
|    Base |  1024 |  24.323 ns | 0.0920 ns | 0.0861 ns |  1.00 |
|      PR |  1024 |  24.192 ns | 0.1332 ns | 0.1180 ns |  0.99 |
|         |       |            |           |           |       |
|    Base |  5552 | 131.578 ns | 0.6836 ns | 0.6394 ns |  1.00 |
|      PR |  5552 |  99.908 ns | 0.3541 ns | 0.3139 ns |  0.76 |
|         |       |            |           |           |       |
|    Base |  8187 | 194.357 ns | 0.5619 ns | 0.4981 ns |  1.00 |
|      PR |  8187 | 152.631 ns | 0.5855 ns | 0.4889 ns |  0.79 |
|         |       |            |           |           |       |
|    Base | 32768 | 667.017 ns | 3.0423 ns | 2.8457 ns |  1.00 |
|      PR | 32768 | 638.717 ns | 3.5795 ns | 3.1732 ns |  0.96 |
```

<details>
<summary>COMPlus_EnableAVX=0 benchmark results</summary>

``` ini
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-6700K CPU 4.00GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100
  [Host]     : .NET Core 3.1.10 (CoreCLR 4.700.20.51601, CoreFX 4.700.20.51901), X64 RyuJIT
  DefaultJob : .NET Core 3.1.10 (CoreCLR 4.700.20.51601, CoreFX 4.700.20.51901), X64 RyuJIT
```

```
| Method | Count |         Mean |     Error |    StdDev | Ratio | RatioSD |
|------- |------ |-------------:|----------:|----------:|------:|--------:|
|   Base |     8 |     8.568 ns | 0.1980 ns | 0.4044 ns |  1.00 |    0.00 |
|     PR |     8 |     3.691 ns | 0.0186 ns | 0.0165 ns |  0.45 |    0.04 |
|        |       |              |           |           |       |         |
|   Base |    15 |    10.985 ns | 0.0305 ns | 0.0286 ns |  1.00 |    0.00 |
|     PR |    15 |     7.533 ns | 0.0286 ns | 0.0254 ns |  0.69 |    0.00 |
|        |       |              |           |           |       |         |
|   Base |    16 |     7.235 ns | 0.0207 ns | 0.0194 ns |  1.00 |    0.00 |
|     PR |    16 |     7.428 ns | 0.0284 ns | 0.0266 ns |  1.03 |    0.01 |
|        |       |              |           |           |       |         |
|   Base |    24 |    10.523 ns | 0.0353 ns | 0.0313 ns |  1.00 |    0.00 |
|     PR |    24 |     9.471 ns | 0.0891 ns | 0.0744 ns |  0.90 |    0.01 |
|        |       |              |           |           |       |         |
|   Base |    31 |    14.657 ns | 0.0769 ns | 0.0682 ns |  1.00 |    0.00 |
|     PR |    31 |    11.714 ns | 0.0474 ns | 0.0420 ns |  0.80 |    0.00 |
|        |       |              |           |           |       |         |
|   Base |    32 |    11.821 ns | 0.0297 ns | 0.0263 ns |  1.00 |    0.00 |
|     PR |    32 |     7.657 ns | 0.0432 ns | 0.0383 ns |  0.65 |    0.00 |
|        |       |              |           |           |       |         |
|   Base |    48 |    17.536 ns | 0.0589 ns | 0.0551 ns |  1.00 |    0.00 |
|     PR |    48 |     8.503 ns | 0.0303 ns | 0.0283 ns |  0.48 |    0.00 |
|        |       |              |           |           |       |         |
|   Base |    64 |     9.387 ns | 0.0769 ns | 0.0719 ns |  1.00 |    0.00 |
|     PR |    64 |     9.145 ns | 0.0451 ns | 0.0422 ns |  0.97 |    0.01 |
|        |       |              |           |           |       |         |
|   Base |    80 |    14.359 ns | 0.0645 ns | 0.0604 ns |  1.00 |    0.00 |
|     PR |    80 |     9.707 ns | 0.0465 ns | 0.0435 ns |  0.68 |    0.00 |
|        |       |              |           |           |       |         |
|   Base |    96 |    11.482 ns | 0.2477 ns | 0.2853 ns |  1.00 |    0.00 |
|     PR |    96 |    10.188 ns | 0.0623 ns | 0.0583 ns |  0.89 |    0.03 |
|        |       |              |           |           |       |         |
|   Base |   112 |    15.146 ns | 0.0660 ns | 0.0617 ns |  1.00 |    0.00 |
|     PR |   112 |    10.839 ns | 0.0324 ns | 0.0287 ns |  0.72 |    0.00 |
|        |       |              |           |           |       |         |
|   Base |  1024 |    45.580 ns | 0.1230 ns | 0.1091 ns |  1.00 |    0.00 |
|     PR |  1024 |    43.515 ns | 0.1820 ns | 0.1702 ns |  0.95 |    0.00 |
|        |       |              |           |           |       |         |
|   Base |  5552 |   222.906 ns | 4.4200 ns | 4.3410 ns |  1.00 |    0.00 |
|     PR |  5552 |   214.824 ns | 0.5211 ns | 0.4620 ns |  0.96 |    0.01 |
|        |       |              |           |           |       |         |
|   Base |  8187 |   324.293 ns | 1.0222 ns | 0.9062 ns |  1.00 |    0.00 |
|     PR |  8187 |   318.943 ns | 1.3859 ns | 1.2964 ns |  0.98 |    0.01 |
|        |       |              |           |           |       |         |
|   Base | 32768 | 1,319.630 ns | 5.3945 ns | 5.0460 ns |  1.00 |    0.00 |
|     PR | 32768 | 1,258.779 ns | 5.9641 ns | 4.9803 ns |  0.95 |    0.01 |
```
</details>

Notice the current implementation actually takes longer on a 112 byte input than it does on 1024 bytes, just because it ends up with 48 trailing bytes after processing 64 with AVX2.  The new version is able to completely vectorize the 112 byte case and makes the performance much more linear as input size grows.

The implementation is slightly simplified, making it easier to follow and saving a few cycles on larger inputs as well.  Hopefully the comments make sense.

I also added a small 4-bytes-at-time loop to the scalar implementation to better handle very small inputs.  I'm not sure how often those would come up in e.g. PNG, but it's a small amount of code and shows good improvements up to 32 bytes where the SIMD code kicks in.

Oh, and I switched over from pointers to managed refs, with no perf hit.